### PR TITLE
Rename variables in puppet::package 

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,12 +1,10 @@
 class puppet::package (
-  $agent_package  = $puppet::params::agent_package,
-  $master_package = $puppet::params::master_package,
+  $agent  = $puppet::params::agent_package,
+  $server = $puppet::params::master_package,
 ) inherits puppet::params {
 
-  $packages = union([$agent_package], [$master_package])
+  $packages = union([$agent], [$server])
   @package { $packages: }
-
-  include puppet::params
 
   if $puppet::agent::manage_repos {
     include puppet::package::repository

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -57,8 +57,6 @@ class puppet::server (
   $stringify_facts    = false,
 ) inherits puppet::params {
 
-  $master = true
-
   include puppet
   include puppet::server::config
   if $manage_package {


### PR DESCRIPTION
Drop the _package suffix, so they will be declared as $puppet::package::agent instead of $puppet::package::agent_package
Rename $master to $server to comply with the $puppet::server name
Remove obsolete includes